### PR TITLE
Unity 2017.2 で発生する警告を除去する

### DIFF
--- a/Assets/Scripts/UnityEngineBridge/ScenePlaybackDetector.cs
+++ b/Assets/Scripts/UnityEngineBridge/ScenePlaybackDetector.cs
@@ -52,7 +52,11 @@ namespace UniRx
         // InitializeOnLoad ensures that this constructor is called when the Unity Editor is started.
         static ScenePlaybackDetector()
         {
+#if UNITY_2017_2_OR_NEWER
+            EditorApplication.pauseStateChanged += (pauseState) =>
+#else
             EditorApplication.playmodeStateChanged += () =>
+#endif
             {
                 // Before scene start:          isPlayingOrWillChangePlaymode = false;  isPlaying = false
                 // Pressed Playback button:     isPlayingOrWillChangePlaymode = true;   isPlaying = false


### PR DESCRIPTION
* 2017.2 から playmodeStateChanged ではなく pauseStateChanged として状態を渡してくれるデリゲートに変わった